### PR TITLE
removes the eventArray object entirely when it's cleared or emptied

### DIFF
--- a/assets/js/listScript.js
+++ b/assets/js/listScript.js
@@ -69,12 +69,17 @@ function renderTask(task) {
 function removeTask(taskElement, task) {
     let tasks = getTasksFromLocalStorage();
     tasks.splice(tasks.indexOf(task), 1);
-    localStorage.setItem('eventArray', JSON.stringify(tasks));
+    if(tasks.length === 0) {
+        localStorage.removeItem('eventArray');
+    }
+    else{
+        localStorage.setItem('eventArray', JSON.stringify(tasks));
+    }
     tasksList.removeChild(taskElement);
 }
 
 // Function to clear all tasks from the list and local storage
 function clearAllTasks() {
     tasksList.innerHTML = '';
-    localStorage.setItem('eventArray', '');
+    localStorage.removeItem('eventArray');
 }


### PR DESCRIPTION
finishes fixing the error by making sure there is no eventArray when the array is cleared (with clearAllTasks) or emptied (by using removeTask on all the tasks individually). this is done by changing the format used to clear all tasks (local storage's remove item is used instead of simply setting eventArray to be empty)